### PR TITLE
ci: add "Update NuGet Lock Files" job for dependabot

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -29,6 +29,45 @@ jobs:
       - name: Lint
         run: dotnet format --verify-no-changes --verbosity detailed
 
+  restore:
+    name: Update NuGet lock file
+    if: contains(github.actor, '[bot]') && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.4.0
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      - uses: actions/cache@v2.1.7
+        with:
+          path: ${{ env.NUGET_PACKAGES }}
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+      - name: Setup .NET Core 3.1 SDK
+        uses: actions/setup-dotnet@v1.9.0
+        with:
+          dotnet-version: 3.1.x
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v1.9.0
+
+      - name: Restore
+        run: dotnet restore --force-evaluate
+      - name: Diff
+        id: diff
+        continue-on-error: true
+        run: |
+          git add -N .
+          git diff --name-only --exit-code
+
+      - name: Commit & Push
+        if: steps.diff.outcome == 'failure'
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git commit -m "chore(deps): update NuGet lock file"
+          git push
+
   test:
     name: Debug Build & Test
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -53,6 +53,10 @@ jobs:
 
       - name: Restore
         run: dotnet restore --force-evaluate
+      - name: Run ECLint
+        run: |
+          npm install -g eclint
+          eclint fix "**/packages.lock.json"
       - name: Diff
         id: diff
         continue-on-error: true

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -30,7 +30,7 @@ jobs:
         run: dotnet format --verify-no-changes --verbosity detailed
 
   restore:
-    name: Update NuGet lock file
+    name: Update NuGet Lock Files
     if: contains(github.actor, '[bot]') && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
- Run `dotnet restore --force-evaluate` on each PR by dependabot
- Run `eclint` for `packages.lock.json` because `dotnet restore` command does not compliant EditorConfig.